### PR TITLE
extract-files: increase maximum buffer size for uncompressed ramdisks

### DIFF
--- a/extract_elf_ramdisk/extract_elf_ramdisk.c
+++ b/extract_elf_ramdisk/extract_elf_ramdisk.c
@@ -46,8 +46,8 @@
 #define EER_TMP_RAMDISK_CPIO "ramdisk.cpio" // temporary ramdisk cpio file name
 #define EER_SEARCH_STRING "fota-ua" // String to search to determine if the
                                     // ramdisk is a stock Sony FOTA ramdisk
-#define MEMORY_BUFFER_SIZE (const size_t)8192*1024 // Max size of uncompressed
-                                                   // ramdisk (8MB)
+#define MEMORY_BUFFER_SIZE (const size_t)14*1024*1024 // Max size of uncompressed
+                                                   // ramdisk (14MB)
 #ifndef PATH_MAX
 #define PATH_MAX 255
 #endif


### PR DESCRIPTION
- This is needed for getting TWRP to boot, because the recovery ramdisk is > 13 MB big.
